### PR TITLE
(feat#4): implemented auth api integration

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -49,5 +49,7 @@ export default {
     isEmailAvailable: (email: string) => api.get<CheckEmailResponse>('/auth/check-email', { params: { email } }),
     isUsernameAvailable: (username: string) => api.get<CheckUsernameResponse>('/auth/check-username', { params: { username } }),
     refreshToken: (data: RefreshTokenRequest) => api.post<RefreshTokenResponse>('/auth/refresh', data),
-    withdraw: (data: WithdrawRequest) => api.post<WithdrawResponse>('/auth/withdraw', data),
+    // NOTE: 백엔드가 DELETE로 탈퇴를 구현한 경우를 우선 지원합니다.
+    // axios의 delete는 body를 config.data로 전달해야 합니다.
+    withdraw: (data: WithdrawRequest) => api.delete<WithdrawResponse>('/auth/withdraw', { data }),
 };

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -43,11 +43,11 @@ export interface WithdrawResponse {
 }
 
 export default {
-    login: (credentials: any) => api.post('/auth/sign-in', credentials),
-    logout: (data: { refreshToken: string }) => api.post('/auth/sign-out', data),
+    signIn: (credentials: any) => api.post('/auth/sign-in', credentials),
+    signOut: (data: { refreshToken: string }) => api.post('/auth/sign-out', data),
     signUp: (data: SignUpRequest) => api.post<SignUpResponse>('/auth/sign-up', data),
-    checkEmail: (email: string) => api.get<CheckEmailResponse>('/auth/check-email', { params: { email } }),
-    checkUsername: (username: string) => api.get<CheckUsernameResponse>('/auth/check-username', { params: { username } }),
+    isEmailAvailable: (email: string) => api.get<CheckEmailResponse>('/auth/check-email', { params: { email } }),
+    isUsernameAvailable: (username: string) => api.get<CheckUsernameResponse>('/auth/check-username', { params: { username } }),
     refreshToken: (data: RefreshTokenRequest) => api.post<RefreshTokenResponse>('/auth/refresh', data),
     withdraw: (data: WithdrawRequest) => api.post<WithdrawResponse>('/auth/withdraw', data),
 };

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -19,4 +19,72 @@ api.interceptors.request.use(
   (error: AxiosError) => Promise.reject(error)
 );
 
+// Response interceptor for token refresh
+let isRefreshing = false;
+let failedQueue: any[] = [];
+
+const processQueue = (error: any, token: string | null = null) => {
+  failedQueue.forEach(prom => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token);
+    }
+  });
+  failedQueue = [];
+};
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalRequest: any = error.config;
+
+    // Check if error is 401 and we haven't tried refreshing yet
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isRefreshing) {
+        // If already refreshing, queue this request
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then(token => {
+            originalRequest.headers.Authorization = `Bearer ${token}`;
+            return api(originalRequest);
+          })
+          .catch(err => Promise.reject(err));
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      // Dynamically import auth store to avoid circular dependency
+      const { useAuthStore } = await import('@/stores/auth');
+      const authStore = useAuthStore();
+
+      try {
+        const success = await authStore.refreshAccessToken();
+
+        if (success) {
+          const newToken = authStore.token;
+          processQueue(null, newToken);
+          originalRequest.headers.Authorization = `Bearer ${newToken}`;
+          return api(originalRequest);
+        } else {
+          processQueue(new Error('Token refresh failed'), null);
+          // Redirect to login
+          window.location.href = '/';
+          return Promise.reject(error);
+        }
+      } catch (refreshError) {
+        processQueue(refreshError, null);
+        window.location.href = '/';
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
 export default api;

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -70,12 +70,36 @@ api.interceptors.response.use(
           return api(originalRequest);
         } else {
           processQueue(new Error('Token refresh failed'), null);
-          // Redirect to login
+          // Redirect to login (preserve a one-time message)
+          try {
+            sessionStorage.setItem(
+              'flash_message',
+              JSON.stringify({
+                type: 'error',
+                message: '세션이 만료되었습니다. 다시 로그인해주세요.',
+                at: Date.now(),
+              })
+            );
+          } catch {
+            // ignore storage errors
+          }
           window.location.href = '/';
           return Promise.reject(error);
         }
       } catch (refreshError) {
         processQueue(refreshError, null);
+        try {
+          sessionStorage.setItem(
+            'flash_message',
+            JSON.stringify({
+              type: 'error',
+              message: '세션이 만료되었습니다. 다시 로그인해주세요.',
+              at: Date.now(),
+            })
+          );
+        } catch {
+          // ignore storage errors
+        }
         window.location.href = '/';
         return Promise.reject(refreshError);
       } finally {

--- a/src/components/ui/Button.vue
+++ b/src/components/ui/Button.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
 import { type VariantProps, cva } from "class-variance-authority";
 import { cn } from "@/lib/utils";
-import { computed } from "vue";
+import { computed, useAttrs } from "vue";
+
+// root 엘리먼트로 attrs(type, disabled, aria-*, onClick 등)를 정확히 전달하기 위해 사용
+defineOptions({ inheritAttrs: false });
+const attrs = useAttrs();
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -48,7 +52,12 @@ const computedClass = computed(() => {
 </script>
 
 <template>
-  <component :is="asChild ? 'slot' : 'button'" :class="computedClass">
+  <!--
+    NOTE:
+    - 기존 구현은 type/disabled/click 등의 attrs가 실제 button에 적용되지 않을 수 있음.
+    - asChild는 현재 코드베이스에서 사용되지 않아, 최소한의 호환성을 위해 span wrapper로 유지.
+  -->
+  <component :is="asChild ? 'span' : 'button'" v-bind="attrs" :class="computedClass">
     <slot />
   </component>
 </template>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -12,13 +12,16 @@ import {
   Utensils,
   Menu,
   X,
+  LogOut,
 } from "lucide-vue-next";
 import Avatar from "@/components/ui/Avatar.vue";
 import AICoachWidget from "@/components/AICoachWidget.vue";
 import { cn } from "@/lib/utils";
+import { useAuthStore } from "@/stores/auth";
 
 const router = useRouter();
 const route = useRoute();
+const authStore = useAuthStore();
 
 const isMobileMenuOpen = ref(false);
 
@@ -48,6 +51,12 @@ const handleMenuClick = (path: string) => {
   isMobileMenuOpen.value = false;
 };
 
+const handleLogout = async () => {
+  await authStore.logout();
+  router.push({ name: "login" });
+  isMobileMenuOpen.value = false;
+};
+
 const today = new Date();
 const formattedDate = `${today.getFullYear()}. ${String(today.getMonth() + 1).padStart(2, "0")}. ${String(
   today.getDate()
@@ -58,7 +67,7 @@ const formattedDate = `${today.getFullYear()}. ${String(today.getMonth() + 1).pa
   <div class="min-h-screen bg-zinc-950 flex">
     <!-- 사이드바 - Desktop -->
     <aside class="hidden lg:flex lg:flex-col lg:w-64 bg-zinc-900 border-r border-zinc-800">
-      <!-- 로고 -->
+        <!-- 로고 -->
       <div class="p-6 border-b border-zinc-800">
         <div class="flex items-center gap-3">
           <Utensils class="w-7 h-7 text-emerald-500" />
@@ -83,11 +92,22 @@ const formattedDate = `${today.getFullYear()}. ${String(today.getMonth() + 1).pa
           <span>{{ item.label }}</span>
         </button>
       </nav>
+      
+      <!-- 로그아웃 (데스크톱) -->
+      <div class="p-4 border-t border-zinc-800">
+        <button
+          @click="handleLogout"
+          class="w-full flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-400 hover:bg-zinc-800 hover:text-white transition-all"
+        >
+          <LogOut class="w-5 h-5" />
+          <span>로그아웃</span>
+        </button>
+      </div>
     </aside>
 
     <!-- 모바일 메뉴 -->
     <div v-if="isMobileMenuOpen" class="lg:hidden fixed inset-0 z-50 bg-black/50" @click="isMobileMenuOpen = false">
-      <aside class="w-64 h-full bg-zinc-900 border-r border-zinc-800" @click.stop>
+      <aside class="w-64 h-full flex flex-col bg-zinc-900 border-r border-zinc-800" @click.stop>
         <!-- 로고 -->
         <div class="p-6 border-b border-zinc-800 flex items-center justify-between">
           <div class="flex items-center gap-3">
@@ -100,7 +120,7 @@ const formattedDate = `${today.getFullYear()}. ${String(today.getMonth() + 1).pa
         </div>
 
         <!-- 메뉴 -->
-        <nav class="p-4 space-y-1">
+        <nav class="p-4 space-y-1 flex-1">
           <button
             v-for="item in menuItems"
             :key="item.id"
@@ -118,6 +138,17 @@ const formattedDate = `${today.getFullYear()}. ${String(today.getMonth() + 1).pa
             <span>{{ item.label }}</span>
           </button>
         </nav>
+        
+        <!-- 로그아웃 (모바일) -->
+        <div class="p-4 border-t border-zinc-800">
+            <button
+            @click="handleLogout"
+            class="w-full flex items-center gap-3 px-4 py-3 rounded-lg text-zinc-400 hover:bg-zinc-800 hover:text-white transition-all"
+            >
+            <LogOut class="w-5 h-5" />
+            <span>로그아웃</span>
+            </button>
+        </div>
       </aside>
     </div>
 
@@ -137,9 +168,9 @@ const formattedDate = `${today.getFullYear()}. ${String(today.getMonth() + 1).pa
           <!-- 우측 -->
           <div class="flex items-center gap-6">
             <span class="text-zinc-400 hidden sm:block">{{ formattedDate }}</span>
-            <div class="flex items-center gap-3">
-              <Avatar class="w-9 h-9" fallback="홍" class-name="bg-emerald-500 text-white" />
-              <span class="text-white hidden sm:block">홍길동</span>
+            <div class="flex items-center gap-3" v-if="authStore.user">
+              <Avatar class="w-9 h-9" :fallback="authStore.user.username.slice(0, 1)" class-name="bg-emerald-500 text-white" />
+              <span class="text-white hidden sm:block">{{ authStore.user.username }}</span>
             </div>
           </div>
         </div>

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -80,6 +80,41 @@ export const useAuthStore = defineStore('auth', () => {
         }
     }
 
+    async function refreshAccessToken(): Promise<boolean> {
+        try {
+            if (!refreshToken.value) {
+                return false;
+            }
+
+            const response = await api.post('/auth/refresh', {
+                refreshToken: refreshToken.value
+            });
+
+            const {
+                accessToken,
+                refreshToken: newRefreshToken,
+            } = response.data;
+
+            token.value = accessToken;
+            refreshToken.value = newRefreshToken;
+
+            localStorage.setItem('token', accessToken);
+            localStorage.setItem('refreshToken', newRefreshToken);
+
+            return true;
+        } catch (error) {
+            console.error('Token refresh failed:', error);
+            // Clear tokens on refresh failure
+            token.value = '';
+            refreshToken.value = '';
+            user.value = null;
+            localStorage.removeItem('token');
+            localStorage.removeItem('refreshToken');
+            localStorage.removeItem('user');
+            return false;
+        }
+    }
+
     async function logout() {
         try {
             if (refreshToken.value) {
@@ -103,6 +138,7 @@ export const useAuthStore = defineStore('auth', () => {
         token,
         isAuthenticated,
         login,
-        logout
+        logout,
+        refreshAccessToken
     };
 });

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -17,6 +17,10 @@ interface LoginResponse {
     userInfo: UserInfo;
 }
 
+interface WithdrawResponse {
+    message: string;
+}
+
 interface ErrorResponse {
     status: number;
     message?: string;
@@ -133,16 +137,31 @@ export const useAuthStore = defineStore('auth', () => {
         }
     }
 
-    async function withdraw(password: string): Promise<boolean> {
+    async function withdraw(password: string): Promise<string> {
         try {
             if (!refreshToken.value) {
                 throw new Error('인증 정보가 없습니다.');
             }
 
-            await api.post('/auth/withdraw', {
+            const payload = {
                 password,
                 refreshToken: refreshToken.value
-            });
+            };
+
+            // NOTE: 백엔드가 POST를 지원하지 않는 경우가 있어(405/메서드 불일치),
+            // 기본은 DELETE로 호출하고 필요 시 POST로 한 번 더 시도합니다.
+            let responseMessage = '회원 탈퇴가 완료되었습니다.';
+            try {
+                const response = await api.delete<WithdrawResponse>('/auth/withdraw', { data: payload });
+                if (response?.data?.message) responseMessage = response.data.message;
+            } catch (err: any) {
+                if (axios.isAxiosError(err) && err.response?.status === 405) {
+                    const response = await api.post<WithdrawResponse>('/auth/withdraw', payload);
+                    if (response?.data?.message) responseMessage = response.data.message;
+                } else {
+                    throw err;
+                }
+            }
 
             // Clear all auth data
             token.value = '';
@@ -152,7 +171,7 @@ export const useAuthStore = defineStore('auth', () => {
             localStorage.removeItem('refreshToken');
             localStorage.removeItem('user');
 
-            return true;
+            return responseMessage;
         } catch (error: any) {
             console.error('Withdrawal failed:', error);
 

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,0 +1,108 @@
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+import axios from 'axios';
+import api from '@/api/axios';
+
+interface UserInfo {
+    email: string;
+    username: string;
+}
+
+interface LoginResponse {
+    accessToken: string;
+    accessTokenExpiresIn: number;
+    refreshToken: string;
+    refreshTokenExpiresIn: number;
+    tokenType: string;
+    userInfo: UserInfo;
+}
+
+interface ErrorResponse {
+    status: number;
+    message?: string;
+    error?: string;
+    code?: string;
+}
+
+export const useAuthStore = defineStore('auth', () => {
+    // Parser helper for safe JSON parsing
+    const safeParse = (key: string) => {
+        try {
+            return JSON.parse(localStorage.getItem(key) || 'null');
+        } catch {
+            return null;
+        }
+    };
+
+    const user = ref<UserInfo | null>(safeParse('user'));
+    const token = ref(localStorage.getItem('token') || '');
+    const refreshToken = ref(localStorage.getItem('refreshToken') || '');
+
+    const isAuthenticated = computed(() => !!token.value);
+
+    async function login(credentials: any) {
+        try {
+            const response = await api.post<LoginResponse>('/auth/sign-in', credentials);
+
+            const {
+                accessToken,
+                refreshToken: newRefreshToken,
+                userInfo
+            } = response.data;
+
+            token.value = accessToken;
+            refreshToken.value = newRefreshToken;
+            user.value = userInfo;
+
+            localStorage.setItem('token', accessToken);
+            localStorage.setItem('refreshToken', newRefreshToken);
+            localStorage.setItem('user', JSON.stringify(userInfo));
+
+            return true;
+        } catch (error: any) {
+            let message = '로그인에 실패했습니다.';
+
+            if (axios.isAxiosError(error) && error.response) {
+                const data = error.response.data as ErrorResponse;
+
+                // Prioritize 'message' field from server
+                if (data.message) {
+                    message = data.message;
+                } else if (data.error) {
+                    message = data.error;
+                } else if (error.response.status === 401) {
+                    message = '인증에 실패했습니다.';
+                }
+            }
+
+            // Allow component to catch and display the message
+            throw new Error(message);
+        }
+    }
+
+    async function logout() {
+        try {
+            if (refreshToken.value) {
+                await api.post('/auth/sign-out', { refreshToken: refreshToken.value });
+            }
+        } catch (error) {
+            console.error('Logout failed on server:', error);
+        } finally {
+            token.value = '';
+            refreshToken.value = '';
+            user.value = null;
+
+            localStorage.removeItem('token');
+            localStorage.removeItem('refreshToken');
+            localStorage.removeItem('user');
+        }
+    }
+
+    return {
+        user,
+        token,
+        isAuthenticated,
+        login,
+        logout
+    };
+});

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -133,12 +133,50 @@ export const useAuthStore = defineStore('auth', () => {
         }
     }
 
+    async function withdraw(password: string): Promise<boolean> {
+        try {
+            if (!refreshToken.value) {
+                throw new Error('인증 정보가 없습니다.');
+            }
+
+            await api.post('/auth/withdraw', {
+                password,
+                refreshToken: refreshToken.value
+            });
+
+            // Clear all auth data
+            token.value = '';
+            refreshToken.value = '';
+            user.value = null;
+            localStorage.removeItem('token');
+            localStorage.removeItem('refreshToken');
+            localStorage.removeItem('user');
+
+            return true;
+        } catch (error: any) {
+            console.error('Withdrawal failed:', error);
+
+            let message = '회원 탈퇴에 실패했습니다.';
+            if (axios.isAxiosError(error) && error.response) {
+                const data = error.response.data as ErrorResponse;
+                if (data.message) {
+                    message = data.message;
+                } else if (data.error) {
+                    message = data.error;
+                }
+            }
+
+            throw new Error(message);
+        }
+    }
+
     return {
         user,
         token,
         isAuthenticated,
         login,
         logout,
-        refreshAccessToken
+        refreshAccessToken,
+        withdraw
     };
 });

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
 import { useAuthStore } from "@/stores/auth";
 import api from "@/api/auth";
@@ -19,6 +19,24 @@ const confirmPassword = ref("");
 const name = ref("");
 const showPassword = ref(false);
 const showConfirmPassword = ref(false);
+const flashMessage = ref<{ type: "error" | "success"; message: string } | null>(null);
+
+onMounted(() => {
+  try {
+    const raw = sessionStorage.getItem("flash_message");
+    if (!raw) return;
+    sessionStorage.removeItem("flash_message");
+    const parsed = JSON.parse(raw) as { type?: unknown; message?: unknown };
+    if (typeof parsed?.message === "string") {
+      flashMessage.value = {
+        type: parsed.type === "success" ? "success" : "error",
+        message: parsed.message,
+      };
+    }
+  } catch {
+    // ignore
+  }
+});
 
 // Email Check State
 const isEmailChecked = ref(false);
@@ -211,6 +229,19 @@ const handleSubmit = async () => {
         <div class="space-y-2">
           <h1 class="text-4xl text-white">{{ isLogin ? "로그인" : "회원가입" }}</h1>
           <p class="text-zinc-400">{{ isLogin ? "계정에 로그인하세요" : "새로운 계정을 만드세요" }}</p>
+        </div>
+
+        <!-- Flash Message (ex: session expired) -->
+        <div
+          v-if="flashMessage"
+          class="rounded-lg border px-4 py-3 text-sm"
+          :class="
+            flashMessage.type === 'success'
+              ? 'bg-emerald-500/10 border-emerald-500/30 text-emerald-300'
+              : 'bg-red-500/10 border-red-500/30 text-red-300'
+          "
+        >
+          {{ flashMessage.message }}
         </div>
 
         <!-- Form -->

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { useRouter } from "vue-router";
+import { useAuthStore } from "@/stores/auth";
+import api from "@/api/auth";
 import { Eye, EyeOff, Utensils } from "lucide-vue-next";
 import Button from "@/components/ui/Button.vue";
 import Input from "@/components/ui/Input.vue";
@@ -8,6 +10,7 @@ import Label from "@/components/ui/Label.vue";
 import ImageWithFallback from "@/components/common/ImageWithFallback.vue";
 
 const router = useRouter();
+const authStore = useAuthStore();
 
 const isLogin = ref(true);
 const email = ref("");
@@ -17,15 +20,28 @@ const name = ref("");
 const showPassword = ref(false);
 const showConfirmPassword = ref(false);
 
-const handleSubmit = () => {
-  if (isLogin.value) {
-    console.log("로그인:", { email: email.value, password: password.value });
-    // 로그인 시 바로 대시보드로 (추후 구현)
-    router.push("/dashboard");
-  } else {
-    console.log("회원가입:", { name: name.value, email: email.value, password: password.value });
-    // 회원가입 시 온보딩 화면으로
-    router.push("/onboarding");
+const handleSubmit = async () => {
+  try {
+    if (isLogin.value) {
+      await authStore.login({ email: email.value, password: password.value });
+      router.push("/dashboard");
+    } else {
+      if (password.value !== confirmPassword.value) {
+        alert("비밀번호가 일치하지 않습니다.");
+        return;
+      }
+      await api.signUp({ 
+        email: email.value, 
+        password: password.value, 
+        username: name.value 
+      });
+      alert("회원가입이 완료되었습니다.");
+      // 회원가입 성공 시 온보딩 페이지로 이동
+      router.push("/onboarding");
+      isLogin.value = true;
+    }
+  } catch (error: any) {
+    alert(error.message || "작업 중 오류가 발생했습니다.");
   }
 };
 </script>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -20,16 +20,64 @@ const name = ref("");
 const showPassword = ref(false);
 const showConfirmPassword = ref(false);
 
+// Email Check State
+const isEmailChecked = ref(false);
+const isEmailAvailable = ref(false);
+const emailCheckMessage = ref("");
+
+const checkEmail = async () => {
+  if (!email.value) {
+    alert("이메일을 입력해주세요.");
+    return;
+  }
+  
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.value)) {
+    alert("올바른 이메일 형식이 아닙니다.");
+    return;
+  }
+
+  try {
+    const response = await api.isEmailAvailable(email.value);
+    // Adjust based on actual API response structure. 
+    // Assuming response.data.available is boolean.
+    isEmailAvailable.value = response.data.available;
+    isEmailChecked.value = true;
+
+    if (isEmailAvailable.value) {
+      emailCheckMessage.value = "사용 가능한 이메일입니다.";
+    } else {
+      emailCheckMessage.value = "이미 사용 중인 이메일입니다.";
+    }
+  } catch (error: any) {
+    console.error(error);
+    alert("이메일 중복 확인 중 오류가 발생했습니다.");
+  }
+};
+
+// Reset check when email changes
+const handleEmailChange = () => {
+  isEmailChecked.value = false;
+  isEmailAvailable.value = false;
+  emailCheckMessage.value = "";
+};
+
 const handleSubmit = async () => {
   try {
     if (isLogin.value) {
       await authStore.login({ email: email.value, password: password.value });
       router.push("/dashboard");
     } else {
+      // Validate Signup
+      if (!isEmailChecked.value || !isEmailAvailable.value) {
+        alert("이메일 중복 확인을 해주세요.");
+        return;
+      }
+
       if (password.value !== confirmPassword.value) {
         alert("비밀번호가 일치하지 않습니다.");
         return;
       }
+      
       await api.signUp({ 
         email: email.value, 
         password: password.value, 
@@ -141,13 +189,32 @@ const handleSubmit = async () => {
 
           <div class="space-y-2">
             <Label class="text-zinc-300"> 이메일 </Label>
-            <Input
-              type="email"
-              placeholder="your@email.com"
-              v-model="email"
-              class="h-12 bg-zinc-900 border-zinc-800 text-white placeholder:text-zinc-600 focus:border-zinc-700"
-              required
-            />
+            <div class="flex gap-2">
+              <Input
+                type="email"
+                placeholder="your@email.com"
+                v-model="email"
+                @input="handleEmailChange"
+                class="h-12 bg-zinc-900 border-zinc-800 text-white placeholder:text-zinc-600 focus:border-zinc-700 flex-1"
+                required
+              />
+              <Button 
+                v-if="!isLogin"
+                type="button" 
+                @click="checkEmail"
+                variant="outline"
+                class="h-12 whitespace-nowrap bg-zinc-800 border-zinc-700 text-white hover:bg-zinc-700"
+              >
+                중복 확인
+              </Button>
+            </div>
+            <!-- Validation Message -->
+            <p v-if="!isLogin && emailCheckMessage" 
+               class="text-sm"
+               :class="isEmailAvailable ? 'text-emerald-500' : 'text-red-500'"
+            >
+              {{ emailCheckMessage }}
+            </p>
           </div>
 
           <div class="space-y-2">

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -25,6 +25,40 @@ const isEmailChecked = ref(false);
 const isEmailAvailable = ref(false);
 const emailCheckMessage = ref("");
 
+// Nickname Check State
+const isNicknameChecked = ref(false);
+const isNicknameAvailable = ref(false);
+const nicknameCheckMessage = ref("");
+
+const checkNickname = async () => {
+  if (!name.value) {
+    alert("닉네임을 입력해주세요.");
+    return;
+  }
+
+  try {
+    const response = await api.isUsernameAvailable(name.value);
+    isNicknameAvailable.value = response.data.available;
+    isNicknameChecked.value = true;
+
+    if (isNicknameAvailable.value) {
+      nicknameCheckMessage.value = "사용 가능한 닉네임입니다.";
+    } else {
+      nicknameCheckMessage.value = "이미 사용 중인 닉네임입니다.";
+    }
+  } catch (error: any) {
+    console.error(error);
+    alert("닉네임 중복 확인 중 오류가 발생했습니다.");
+  }
+};
+
+// Reset check when nickname changes
+const handleNicknameChange = () => {
+  isNicknameChecked.value = false;
+  isNicknameAvailable.value = false;
+  nicknameCheckMessage.value = "";
+};
+
 const checkEmail = async () => {
   if (!email.value) {
     alert("이메일을 입력해주세요.");
@@ -70,6 +104,11 @@ const handleSubmit = async () => {
       // Validate Signup
       if (!isEmailChecked.value || !isEmailAvailable.value) {
         alert("이메일 중복 확인을 해주세요.");
+        return;
+      }
+
+      if (!isNicknameChecked.value || !isNicknameAvailable.value) {
+        alert("닉네임 중복 확인을 해주세요.");
         return;
       }
 
@@ -177,14 +216,32 @@ const handleSubmit = async () => {
         <!-- Form -->
         <form @submit.prevent="handleSubmit" class="space-y-5">
           <div v-if="!isLogin" class="space-y-2">
-            <Label class="text-zinc-300"> 이름 </Label>
-            <Input
-              type="text"
-              placeholder="홍길동"
-              v-model="name"
-              class="h-12 bg-zinc-900 border-zinc-800 text-white placeholder:text-zinc-600 focus:border-zinc-700"
-              :required="!isLogin"
-            />
+            <Label class="text-zinc-300"> 닉네임 </Label>
+            <div class="flex gap-2">
+              <Input
+                type="text"
+                placeholder="홍길동"
+                v-model="name"
+                @input="handleNicknameChange"
+                class="h-12 bg-zinc-900 border-zinc-800 text-white placeholder:text-zinc-600 focus:border-zinc-700 flex-1"
+                :required="!isLogin"
+              />
+              <Button 
+                type="button" 
+                @click="checkNickname"
+                variant="outline"
+                class="h-12 whitespace-nowrap bg-zinc-800 border-zinc-700 text-white hover:bg-zinc-700"
+              >
+                중복 확인
+              </Button>
+            </div>
+            <!-- Validation Message -->
+             <p v-if="nicknameCheckMessage" 
+               class="text-sm"
+               :class="isNicknameAvailable ? 'text-emerald-500' : 'text-red-500'"
+            >
+              {{ nicknameCheckMessage }}
+            </p>
           </div>
 
           <div class="space-y-2">

--- a/src/views/MyPageView.vue
+++ b/src/views/MyPageView.vue
@@ -164,12 +164,16 @@ const handleHealthInfoSave = () => {
 // Withdrawal State
 const showWithdrawalDialog = ref(false);
 const withdrawalPassword = ref("");
-const withdrawalStep = ref<"password" | "final-confirm">("password");
+const withdrawalStep = ref<"password" | "final-confirm" | "done">("password");
 const isWithdrawing = ref(false);
+const withdrawalErrorMessage = ref<string>("");
+const withdrawalDoneMessage = ref<string>("");
 
 const handleWithdrawClick = () => {
   showWithdrawalDialog.value = true;
   withdrawalStep.value = "password";
+  withdrawalErrorMessage.value = "";
+  withdrawalDoneMessage.value = "";
 };
 
 const handleWithdrawalCancel = () => {
@@ -177,6 +181,8 @@ const handleWithdrawalCancel = () => {
   withdrawalPassword.value = "";
   withdrawalStep.value = "password";
   isWithdrawing.value = false;
+  withdrawalErrorMessage.value = "";
+  withdrawalDoneMessage.value = "";
 };
 
 const handleDialogBackdropClick = (event: MouseEvent) => {
@@ -187,8 +193,9 @@ const handleDialogBackdropClick = (event: MouseEvent) => {
 };
 
 const goToWithdrawalFinalConfirm = () => {
+  withdrawalErrorMessage.value = "";
   if (!withdrawalPassword.value) {
-    alert("비밀번호를 입력해주세요.");
+    withdrawalErrorMessage.value = "비밀번호를 입력해주세요.";
     return;
   }
   withdrawalStep.value = "final-confirm";
@@ -196,8 +203,9 @@ const goToWithdrawalFinalConfirm = () => {
 
 const handleWithdrawalConfirm = async () => {
   if (isWithdrawing.value) return;
+  withdrawalErrorMessage.value = "";
   if (!withdrawalPassword.value) {
-    alert("비밀번호를 입력해주세요.");
+    withdrawalErrorMessage.value = "비밀번호를 입력해주세요.";
     withdrawalStep.value = "password";
     return;
   }
@@ -205,16 +213,20 @@ const handleWithdrawalConfirm = async () => {
   isWithdrawing.value = true;
   try {
     await authStore.withdraw(withdrawalPassword.value);
-    alert("회원 탈퇴가 완료되었습니다.");
-    router.push("/");
+    withdrawalDoneMessage.value = "회원 탈퇴가 완료되었습니다.";
+    withdrawalStep.value = "done";
   } catch (error: any) {
-    alert(error.message || "회원 탈퇴 중 오류가 발생했습니다.");
+    withdrawalErrorMessage.value = error?.message || "회원 탈퇴 중 오류가 발생했습니다.";
+    // 실패 시에는 모달을 닫지 않고 그대로 유지(재시도 가능)
   } finally {
     isWithdrawing.value = false;
-    showWithdrawalDialog.value = false;
-    withdrawalPassword.value = "";
-    withdrawalStep.value = "password";
+    // success일 때만 done 단계로 이동 (위 try에서 처리)
   }
+};
+
+const finishWithdrawalFlow = () => {
+  handleWithdrawalCancel();
+  router.push("/");
 };
 
 
@@ -534,6 +546,13 @@ const getDifficultyColor = (difficulty: string) => {
             </p>
           </div>
 
+          <div
+            v-if="withdrawalErrorMessage"
+            class="bg-red-500/10 border border-red-500/30 text-red-300 rounded-lg px-4 py-3 text-sm"
+          >
+            {{ withdrawalErrorMessage }}
+          </div>
+
           <div class="space-y-2">
             <Label class="text-zinc-300">비밀번호</Label>
             <Input
@@ -564,12 +583,19 @@ const getDifficultyColor = (difficulty: string) => {
           </div>
         </template>
 
-        <template v-else>
+        <template v-else-if="withdrawalStep === 'final-confirm'">
           <div class="space-y-2">
             <h3 class="text-2xl text-white">정말 탈퇴할까요?</h3>
             <p class="text-zinc-400">
               이 작업은 되돌릴 수 없으며, 모든 데이터가 영구적으로 삭제됩니다.
             </p>
+          </div>
+
+          <div
+            v-if="withdrawalErrorMessage"
+            class="bg-red-500/10 border border-red-500/30 text-red-300 rounded-lg px-4 py-3 text-sm"
+          >
+            {{ withdrawalErrorMessage }}
           </div>
 
           <div class="bg-zinc-800 border border-zinc-700 rounded-lg p-4 space-y-2">
@@ -600,6 +626,19 @@ const getDifficultyColor = (difficulty: string) => {
             >
               <span v-if="isWithdrawing">처리 중...</span>
               <span v-else>탈퇴 확정</span>
+            </Button>
+          </div>
+        </template>
+
+        <template v-else>
+          <div class="space-y-2">
+            <h3 class="text-2xl text-white">탈퇴 완료</h3>
+            <p class="text-zinc-400">{{ withdrawalDoneMessage || "처리가 완료되었습니다." }}</p>
+          </div>
+
+          <div class="flex justify-end">
+            <Button type="button" @click="finishWithdrawalFlow" class="bg-emerald-500 hover:bg-emerald-600 text-white">
+              확인
             </Button>
           </div>
         </template>

--- a/src/views/MyPageView.vue
+++ b/src/views/MyPageView.vue
@@ -212,8 +212,8 @@ const handleWithdrawalConfirm = async () => {
 
   isWithdrawing.value = true;
   try {
-    await authStore.withdraw(withdrawalPassword.value);
-    withdrawalDoneMessage.value = "회원 탈퇴가 완료되었습니다.";
+    const message = await authStore.withdraw(withdrawalPassword.value);
+    withdrawalDoneMessage.value = message || "회원 탈퇴가 완료되었습니다.";
     withdrawalStep.value = "done";
   } catch (error: any) {
     withdrawalErrorMessage.value = error?.message || "회원 탈퇴 중 오류가 발생했습니다.";

--- a/src/views/MyPageView.vue
+++ b/src/views/MyPageView.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
+import { useRouter } from "vue-router";
+import { useAuthStore } from "@/stores/auth";
 import { Upload, Save, Lock } from "lucide-vue-next";
 import Button from "@/components/ui/Button.vue";
 import Input from "@/components/ui/Input.vue";
@@ -7,6 +9,9 @@ import Label from "@/components/ui/Label.vue";
 import Textarea from "@/components/ui/Textarea.vue";
 import Avatar from "@/components/ui/Avatar.vue";
 import Checkbox from "@/components/ui/Checkbox.vue";
+
+const router = useRouter();
+const authStore = useAuthStore();
 
 interface Badge {
   id: string;
@@ -156,6 +161,61 @@ const handleHealthInfoSave = () => {
   });
 };
 
+// Withdrawal State
+const showWithdrawalDialog = ref(false);
+const withdrawalPassword = ref("");
+const withdrawalStep = ref<"password" | "final-confirm">("password");
+const isWithdrawing = ref(false);
+
+const handleWithdrawClick = () => {
+  showWithdrawalDialog.value = true;
+  withdrawalStep.value = "password";
+};
+
+const handleWithdrawalCancel = () => {
+  showWithdrawalDialog.value = false;
+  withdrawalPassword.value = "";
+  withdrawalStep.value = "password";
+  isWithdrawing.value = false;
+};
+
+const handleDialogBackdropClick = (event: MouseEvent) => {
+  // 다이얼로그 배경(backdrop)을 클릭했을 때만 닫기
+  if (event.target === event.currentTarget) {
+    handleWithdrawalCancel();
+  }
+};
+
+const goToWithdrawalFinalConfirm = () => {
+  if (!withdrawalPassword.value) {
+    alert("비밀번호를 입력해주세요.");
+    return;
+  }
+  withdrawalStep.value = "final-confirm";
+};
+
+const handleWithdrawalConfirm = async () => {
+  if (isWithdrawing.value) return;
+  if (!withdrawalPassword.value) {
+    alert("비밀번호를 입력해주세요.");
+    withdrawalStep.value = "password";
+    return;
+  }
+
+  isWithdrawing.value = true;
+  try {
+    await authStore.withdraw(withdrawalPassword.value);
+    alert("회원 탈퇴가 완료되었습니다.");
+    router.push("/");
+  } catch (error: any) {
+    alert(error.message || "회원 탈퇴 중 오류가 발생했습니다.");
+  } finally {
+    isWithdrawing.value = false;
+    showWithdrawalDialog.value = false;
+    withdrawalPassword.value = "";
+    withdrawalStep.value = "password";
+  }
+};
 
 
 const getDifficultyColor = (difficulty: string) => {
@@ -426,6 +486,125 @@ const getDifficultyColor = (difficulty: string) => {
           </Button>
         </div>
       </div>
+
+      <!-- 섹션 4: 회원 탈퇴 -->
+      <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-8 space-y-4">
+        <h2 class="text-2xl text-white">회원 탈퇴</h2>
+        
+        <div class="bg-zinc-800 border border-zinc-700 rounded-lg p-4 space-y-2">
+          <p class="text-zinc-300 text-sm">
+            ⚠️ 회원 탈퇴 시 모든 데이터가 영구적으로 삭제되며 복구할 수 없습니다.
+          </p>
+          <ul class="text-zinc-400 text-sm space-y-1 ml-4 list-disc">
+            <li>프로필 정보 및 건강 데이터</li>
+            <li>식단 및 운동 기록</li>
+            <li>챌린지 참여 내역 및 뱃지</li>
+            <li>커뮤니티 게시글 및 댓글</li>
+          </ul>
+        </div>
+
+        <div class="flex justify-end">
+          <Button 
+            @click="handleWithdrawClick" 
+            variant="outline"
+            class="bg-red-900/20 border-red-700 text-red-400 hover:bg-red-900/40"
+          >
+            회원 탈퇴
+          </Button>
+        </div>
+      </div>
     </div>
+
+    <!-- Withdrawal Dialog -->
+    <Teleport to="body">
+      <div 
+        v-if="showWithdrawalDialog"
+        class="fixed inset-0 bg-black/70 flex items-center justify-center z-50"
+        @click="handleDialogBackdropClick"
+      >
+      <div 
+        class="bg-zinc-900 border border-zinc-800 rounded-xl p-8 max-w-md w-full mx-4 space-y-6"
+        @click.stop
+      >
+        <template v-if="withdrawalStep === 'password'">
+          <div class="space-y-2">
+            <h3 class="text-2xl text-white">회원 탈퇴</h3>
+            <p class="text-zinc-400">
+              회원 탈퇴를 진행하려면 비밀번호를 입력해주세요.
+            </p>
+          </div>
+
+          <div class="space-y-2">
+            <Label class="text-zinc-300">비밀번호</Label>
+            <Input
+              type="password"
+              v-model="withdrawalPassword"
+              placeholder="비밀번호를 입력하세요"
+              class="h-12 bg-zinc-800 border-zinc-700 text-white placeholder:text-zinc-600"
+              @keyup.enter="goToWithdrawalFinalConfirm"
+            />
+          </div>
+
+          <div class="flex gap-3 justify-end">
+            <Button 
+              type="button"
+              @click="handleWithdrawalCancel"
+              variant="outline"
+              class="bg-zinc-800 border-zinc-700 text-white hover:bg-zinc-700"
+            >
+              취소
+            </Button>
+            <Button 
+              type="button"
+              @click="goToWithdrawalFinalConfirm"
+              class="bg-red-600 hover:bg-red-700 text-white"
+            >
+              다음
+            </Button>
+          </div>
+        </template>
+
+        <template v-else>
+          <div class="space-y-2">
+            <h3 class="text-2xl text-white">정말 탈퇴할까요?</h3>
+            <p class="text-zinc-400">
+              이 작업은 되돌릴 수 없으며, 모든 데이터가 영구적으로 삭제됩니다.
+            </p>
+          </div>
+
+          <div class="bg-zinc-800 border border-zinc-700 rounded-lg p-4 space-y-2">
+            <p class="text-zinc-300 text-sm">삭제되는 항목</p>
+            <ul class="text-zinc-400 text-sm space-y-1 ml-4 list-disc">
+              <li>프로필 정보 및 건강 데이터</li>
+              <li>식단 및 운동 기록</li>
+              <li>챌린지 참여 내역 및 뱃지</li>
+              <li>커뮤니티 게시글 및 댓글</li>
+            </ul>
+          </div>
+
+          <div class="flex gap-3 justify-end">
+            <Button
+              type="button"
+              @click="() => (withdrawalStep = 'password')"
+              variant="outline"
+              class="bg-zinc-800 border-zinc-700 text-white hover:bg-zinc-700"
+              :disabled="isWithdrawing"
+            >
+              뒤로
+            </Button>
+            <Button
+              type="button"
+              @click="handleWithdrawalConfirm"
+              class="bg-red-600 hover:bg-red-700 text-white"
+              :disabled="isWithdrawing"
+            >
+              <span v-if="isWithdrawing">처리 중...</span>
+              <span v-else>탈퇴 확정</span>
+            </Button>
+          </div>
+        </template>
+      </div>
+    </div>
+    </Teleport>
   </div>
 </template>

--- a/src/views/MyPageView.vue
+++ b/src/views/MyPageView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { Upload, LogOut, Save, Lock } from "lucide-vue-next";
+import { Upload, Save, Lock } from "lucide-vue-next";
 import Button from "@/components/ui/Button.vue";
 import Input from "@/components/ui/Input.vue";
 import Label from "@/components/ui/Label.vue";
@@ -156,9 +156,7 @@ const handleHealthInfoSave = () => {
   });
 };
 
-const handleLogout = () => {
-  console.log("로그아웃");
-};
+
 
 const getDifficultyColor = (difficulty: string) => {
   switch (difficulty) {
@@ -238,14 +236,7 @@ const getDifficultyColor = (difficulty: string) => {
                 <Save class="w-4 h-4 mr-2" />
                 프로필 편집
               </Button>
-              <Button
-                @click="handleLogout"
-                variant="outline"
-                class="bg-zinc-800 border-zinc-700 text-white hover:bg-zinc-700"
-              >
-                <LogOut class="w-4 h-4 mr-2" />
-                로그아웃
-              </Button>
+
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 🔗 관련 이슈

> #4 

## ✨ 작업 내용

- API 클라이언트 함수 이름을 수정하고, Axios 인스턴스를 생성하는 함수에 withCredentials 옵션을 추가했습니다.
- refreshToken을 body로 전달해 사용하기 때문에 withCredentials 옵션이 필수가 아니어서 제거했습니다.
- 스토어에 인증(Auth) API 관련 상태 관리 로직을 추가했습니다.
- 인증(Auth) API를 UI에 연동했습니다.

## 📌 참고 사항

> 없습니다.
