### PR TITLE
feat(#19): AI 식단 평가 연동 및 데이터 동기화 로직 구현 및 식단 API 쪽 필드명 수정

### DIFF
--- a/src/api/diet/index.ts
+++ b/src/api/diet/index.ts
@@ -31,21 +31,15 @@ export type DietTimeSlot = "BREAKFAST" | "LUNCH" | "DINNER" | "SNACK";
  * - items[].unit: "g"
  */
 export interface CreateMyDietItemRequest {
-  foodId?: number | null; // Long (선택, nullable)
-  foodName?: string; // 직접 입력 시 사용
-  serveCount: number; // Double (NotNull, Positive) - 인분 또는 그램 단위
-  calories?: number; // Double (PositiveOrZero)
-  carbs?: number; // Double (PositiveOrZero)
-  protein?: number; // Double (PositiveOrZero)
-  fat?: number; // Double (PositiveOrZero)
+  foodId: number; // Long (NotNull)
+  serveCount: number; // Double (NotNull, Positive) - 인분 단위 (1 = 1인분, 1.5 = 1.5인분)
   orderIndex: number; // Integer (NotNull, Positive) - 식단 내 표시 순서
 }
 
 export interface CreateMyDietRequest {
-  date: string; // ISO datetime 형식 (e.g. "2025-12-05T08:30:00") - 날짜와 시간 정보 포함
-  timeSlot: DietTimeSlot; // "BREAKFAST" | "LUNCH" | "DINNER" | "SNACK"
+  recordedAt: string; // ISO datetime 형식 (e.g. "2025-12-01T00:00:00")
+  mealType: DietTimeSlot; // "BREAKFAST" | "LUNCH" | "DINNER" | "SNACK"
   items: CreateMyDietItemRequest[];
-  memo?: string;
 }
 
 // 백엔드 응답은 ResponseEntity<Long> 형태로 보임(식단 기록 ID)
@@ -58,21 +52,15 @@ export interface DeleteMyDietResponse {
 }
 
 export interface UpdateMyDietItemRequest {
-  foodId?: number | null; // Long (선택, nullable)
-  foodName?: string; // 직접 입력 시 사용
-  serveCount: number; // Double (NotNull, Positive) - 인분 또는 그램 단위
-  calories?: number; // Double (PositiveOrZero)
-  carbs?: number; // Double (PositiveOrZero)
-  protein?: number; // Double (PositiveOrZero)
-  fat?: number; // Double (PositiveOrZero)
-  orderIndex: number; // Integer (NotNull, Positive) - 식단 내 표시 순서
+  foodId: number;
+  serveCount: number;
+  orderIndex: number;
 }
 
 export interface UpdateMyDietRequest {
-  date: string; // ISO datetime 형식 (e.g. "2025-12-05T08:30:00") - 날짜와 시간 정보 포함
-  timeSlot: DietTimeSlot;
+  recordedAt: string;
+  mealType: DietTimeSlot;
   items: UpdateMyDietItemRequest[];
-  memo?: string;
 }
 
 export interface UpdateMyDietItemResponse {
@@ -147,22 +135,20 @@ export default {
    * 내 식단 한 건 수정
    * PUT /api/me/diets/{dietId}
    */
-  updateMyDiet: (dietId: number, data: UpdateMyDietRequest) => 
+  updateMyDiet: (dietId: number, data: UpdateMyDietRequest) =>
     api.put<UpdateMyDietResponse>(`/me/diets/${dietId}`, data),
 
   /**
    * 특정 날짜의 내 식단 기록 전체 조회
    * GET /api/me/diets?date=YYYY-MM-DD
    */
-  getMyDiets: (date: string) => 
-    api.get<GetMyDietsResponse>(`/me/diets`, { params: { date } }),
+  getMyDiets: (date: string) => api.get<GetMyDietsResponse>(`/me/diets`, { params: { date } }),
 
   /**
    * 내 특정 식단 한 건의 상세 내역 조회
    * GET /api/me/diets/{dietId}
    */
-  getMyDietDetail: (dietId: number) => 
-    api.get<GetMyDietDetailResponse>(`/me/diets/${dietId}`),
+  getMyDietDetail: (dietId: number) => api.get<GetMyDietDetailResponse>(`/me/diets/${dietId}`),
 
   // Foods
   /**
@@ -172,15 +158,15 @@ export default {
    * Authorization: Bearer {accessToken} (axios interceptor에서 자동 첨부)
    */
   getFoods: (params?: FoodListParams) => {
-    console.log('🌐 [dietApi] getFoods 호출, params:', params);
+    console.log("🌐 [dietApi] getFoods 호출, params:", params);
     const result = api.get<FoodListResponse>(`/foods`, { params });
     result.then(
       (response) => {
-        console.log('🌐 [dietApi] getFoods 응답:', response);
-        console.log('🌐 [dietApi] response.data:', response.data);
+        console.log("🌐 [dietApi] getFoods 응답:", response);
+        console.log("🌐 [dietApi] response.data:", response.data);
       },
       (error) => {
-        console.error('🌐 [dietApi] getFoods 에러:', error);
+        console.error("🌐 [dietApi] getFoods 에러:", error);
       }
     );
     return result;

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -72,79 +72,81 @@ const getTodayDate = () => {
 };
 
 // 식단 목록을 저장할 ref (식단별로 표시용)
-const displayedDiets = ref<Array<{
-  dietId: number;
-  timeSlot: string;
-  timeSlotLabel: string;
-  time: string; // HH:mm 형식
-  totalCalories: number;
-  totalCarbs: number;
-  totalProtein: number;
-  totalFat: number;
-  items: Array<{ name: string; amount: number; calories: number; carbs: number; protein: number; fat: number }>;
-}>>([]);
+const displayedDiets = ref<
+  Array<{
+    dietId: number;
+    timeSlot: string;
+    timeSlotLabel: string;
+    time: string; // HH:mm 형식
+    totalCalories: number;
+    totalCarbs: number;
+    totalProtein: number;
+    totalFat: number;
+    items: Array<{ name: string; amount: number; calories: number; carbs: number; protein: number; fat: number }>;
+  }>
+>([]);
 
 const fetchTodayDiets = async () => {
   try {
     const today = getTodayDate();
-    console.log('📅 [Dashboard] 오늘 날짜:', today);
-    console.log('📞 [Dashboard] getMyDiets API 호출 시작');
+    console.log("📅 [Dashboard] 오늘 날짜:", today);
+    console.log("📞 [Dashboard] getMyDiets API 호출 시작");
     const res = await dietStore.getMyDiets(today);
-    console.log('✅ [Dashboard] getMyDiets API 응답:', res);
-    console.log('✅ [Dashboard] res 타입:', typeof res);
-    console.log('✅ [Dashboard] res가 배열인가?', Array.isArray(res));
-    console.log('✅ [Dashboard] res.diets:', res.diets);
-    
+    console.log("✅ [Dashboard] getMyDiets API 응답:", res);
+    console.log("✅ [Dashboard] res 타입:", typeof res);
+    console.log("✅ [Dashboard] res가 배열인가?", Array.isArray(res));
+    console.log("✅ [Dashboard] res.diets:", res.diets);
+
     // API 응답 구조에 따라 유연하게 처리
     let diets: any[] = [];
     if (Array.isArray(res)) {
       // 백엔드가 직접 배열을 반환하는 경우
-      console.log('✅ [Dashboard] 배열로 직접 반환됨');
+      console.log("✅ [Dashboard] 배열로 직접 반환됨");
       diets = res;
-    } else if (res && typeof res === 'object' && res.diets && Array.isArray(res.diets)) {
+    } else if (res && typeof res === "object" && res.diets && Array.isArray(res.diets)) {
       // 백엔드가 { date, diets } 형태로 반환하는 경우
-      console.log('✅ [Dashboard] { date, diets } 형태로 반환됨');
+      console.log("✅ [Dashboard] { date, diets } 형태로 반환됨");
       diets = res.diets;
     } else {
-      console.log('⚠️ [Dashboard] 예상치 못한 응답 구조:', res);
+      console.log("⚠️ [Dashboard] 예상치 못한 응답 구조:", res);
       diets = [];
     }
-    
-    console.log('📋 [Dashboard] 최종 diets 배열:', diets);
-    console.log('📋 [Dashboard] diets 개수:', diets.length);
-    
+
+    console.log("📋 [Dashboard] 최종 diets 배열:", diets);
+    console.log("📋 [Dashboard] diets 개수:", diets.length);
+
     // 각 diet 객체의 상세 정보 로그
     if (diets.length > 0) {
-      console.log('🔍 [Dashboard] 첫 번째 diet 상세:', JSON.stringify(diets[0], null, 2));
-      console.log('🔍 [Dashboard] 첫 번째 diet의 모든 키:', Object.keys(diets[0]));
-      console.log('🔍 [Dashboard] 첫 번째 diet.items:', diets[0].items);
-      console.log('🔍 [Dashboard] 첫 번째 diet.items 타입:', typeof diets[0].items);
-      console.log('🔍 [Dashboard] 첫 번째 diet.items가 배열인가?', Array.isArray(diets[0].items));
-      console.log('🔍 [Dashboard] 첫 번째 diet.items가 null인가?', diets[0].items === null);
-      console.log('🔍 [Dashboard] 첫 번째 diet.items가 undefined인가?', diets[0].items === undefined);
-      console.log('🔍 [Dashboard] 첫 번째 diet.totalCalories:', diets[0].totalCalories);
-      console.log('🔍 [Dashboard] 첫 번째 diet.timeSlot:', diets[0].timeSlot);
-      console.log('🔍 [Dashboard] 첫 번째 diet.createdAt:', diets[0].createdAt);
-      
+      console.log("🔍 [Dashboard] 첫 번째 diet 상세:", JSON.stringify(diets[0], null, 2));
+      console.log("🔍 [Dashboard] 첫 번째 diet의 모든 키:", Object.keys(diets[0]));
+      console.log("🔍 [Dashboard] 첫 번째 diet.items:", diets[0].items);
+      console.log("🔍 [Dashboard] 첫 번째 diet.items 타입:", typeof diets[0].items);
+      console.log("🔍 [Dashboard] 첫 번째 diet.items가 배열인가?", Array.isArray(diets[0].items));
+      console.log("🔍 [Dashboard] 첫 번째 diet.items가 null인가?", diets[0].items === null);
+      console.log("🔍 [Dashboard] 첫 번째 diet.items가 undefined인가?", diets[0].items === undefined);
+      console.log("🔍 [Dashboard] 첫 번째 diet.totalCalories:", diets[0].totalCalories);
+      console.log("🔍 [Dashboard] 첫 번째 diet.timeSlot:", diets[0].timeSlot);
+      console.log("🔍 [Dashboard] 첫 번째 diet.createdAt:", diets[0].createdAt);
+
       // items 대신 다른 필드명을 사용하는지 확인
-      console.log('🔍 [Dashboard] 첫 번째 diet.dietItems:', diets[0].dietItems);
-      console.log('🔍 [Dashboard] 첫 번째 diet.foods:', diets[0].foods);
-      console.log('🔍 [Dashboard] 첫 번째 diet.foodItems:', diets[0].foodItems);
+      console.log("🔍 [Dashboard] 첫 번째 diet.dietItems:", diets[0].dietItems);
+      console.log("🔍 [Dashboard] 첫 번째 diet.foods:", diets[0].foods);
+      console.log("🔍 [Dashboard] 첫 번째 diet.foodItems:", diets[0].foodItems);
     }
-    
+
     // 날짜 추출 (res가 객체면 res.date, 배열이면 오늘 날짜 사용)
-    const responseDate = (typeof res === 'object' && !Array.isArray(res) && res.date) ? res.date : today;
-    
+    const responseDate = typeof res === "object" && !Array.isArray(res) && res.date ? res.date : today;
+
     // Convert to DietRecord format for compatibility
     // 백엔드 응답 구조: { id, mealType, date (시간 포함), items: null, ... }
     const dietRecords: DietRecord[] = diets.map((diet: any) => {
       // items가 null이거나 undefined인 경우 빈 배열로 처리
       let items: any[] = [];
-      
+
       if (diet.items !== null && diet.items !== undefined && Array.isArray(diet.items)) {
         items = diet.items;
       }
-      
+
       // 백엔드 필드명 매핑: id → dietId, mealType → timeSlot
       // date 필드에 시간 정보가 포함되어 있으므로 우선 사용
       const dateTimeForRecord = diet.date || diet.recordedAt || `${responseDate}T12:00:00`;
@@ -153,13 +155,13 @@ const fetchTodayDiets = async () => {
         recordedAt: dateTimeForRecord,
         mealType: diet.mealType || diet.timeSlot,
         items: items.map((item: any) => ({
-          name: item?.name || '',
+          name: item?.name || "",
           serveCount: item?.amount || item?.serveCount || 0,
         })),
         totalCalories: diet.totalCalories || 0,
       };
     });
-    
+
     todayDiets.value = dietRecords;
 
     // 식단 목록 표시용 데이터 생성
@@ -171,7 +173,7 @@ const fetchTodayDiets = async () => {
         const timeSlot = diet.mealType || diet.timeSlot; // mealType이 실제 필드명
         // date 필드에 시간 정보가 포함되어 있으므로 우선 사용, 없으면 recordedAt 또는 createdAt 사용
         const dateTime = diet.date || diet.recordedAt || diet.createdAt;
-        
+
         // items가 null이면 상세 조회로 가져오기
         let items: any[] = [];
         if (diet.items !== null && diet.items !== undefined && Array.isArray(diet.items)) {
@@ -185,10 +187,10 @@ const fetchTodayDiets = async () => {
             console.log(`✅ [Dashboard] detail.items:`, detail.items);
             console.log(`✅ [Dashboard] detail.items 타입:`, typeof detail.items);
             console.log(`✅ [Dashboard] detail.items가 배열인가?`, Array.isArray(detail.items));
-            
+
             if (detail.items && Array.isArray(detail.items) && detail.items.length > 0) {
               items = detail.items;
-              console.log(`✅ [Dashboard] dietId ${dietId}의 items 가져옴:`, items.length, '개');
+              console.log(`✅ [Dashboard] dietId ${dietId}의 items 가져옴:`, items.length, "개");
               console.log(`✅ [Dashboard] 첫 번째 item:`, items[0]);
               console.log(`✅ [Dashboard] 첫 번째 item의 모든 키:`, Object.keys(items[0]));
               console.log(`✅ [Dashboard] 첫 번째 item.name:`, items[0].name);
@@ -200,7 +202,7 @@ const fetchTodayDiets = async () => {
             console.error(`❌ [Dashboard] dietId ${dietId} 상세 조회 실패:`, e);
           }
         }
-        
+
         let timeSlotLabel = "";
         switch (timeSlot) {
           case "BREAKFAST":
@@ -225,51 +227,67 @@ const fetchTodayDiets = async () => {
           try {
             const date = new Date(dateTime);
             if (!isNaN(date.getTime())) {
-              const hours = String(date.getHours()).padStart(2, '0');
-              const minutes = String(date.getMinutes()).padStart(2, '0');
+              const hours = String(date.getHours()).padStart(2, "0");
+              const minutes = String(date.getMinutes()).padStart(2, "0");
               timeStr = `${hours}:${minutes}`;
               console.log(`✅ [Dashboard] dietId ${dietId}의 시간 추출: ${dateTime} → ${timeStr}`);
             } else {
-              throw new Error('Invalid date');
+              throw new Error("Invalid date");
             }
           } catch (e) {
             console.warn(`⚠️ [Dashboard] dietId ${dietId}의 dateTime 파싱 실패: ${dateTime}`, e);
             // dateTime 파싱 실패 시 timeSlot에 따라 기본값 사용
             switch (timeSlot) {
-              case "BREAKFAST": timeStr = "08:00"; break;
-              case "LUNCH": timeStr = "12:30"; break;
-              case "DINNER": timeStr = "19:00"; break;
-              case "SNACK": timeStr = "15:00"; break;
+              case "BREAKFAST":
+                timeStr = "08:00";
+                break;
+              case "LUNCH":
+                timeStr = "12:30";
+                break;
+              case "DINNER":
+                timeStr = "19:00";
+                break;
+              case "SNACK":
+                timeStr = "15:00";
+                break;
             }
           }
         } else {
           // dateTime이 없으면 timeSlot에 따라 기본값
           console.warn(`⚠️ [Dashboard] dietId ${dietId}의 dateTime이 없음, timeSlot 기본값 사용`);
           switch (timeSlot) {
-            case "BREAKFAST": timeStr = "08:00"; break;
-            case "LUNCH": timeStr = "12:30"; break;
-            case "DINNER": timeStr = "19:00"; break;
-            case "SNACK": timeStr = "15:00"; break;
+            case "BREAKFAST":
+              timeStr = "08:00";
+              break;
+            case "LUNCH":
+              timeStr = "12:30";
+              break;
+            case "DINNER":
+              timeStr = "19:00";
+              break;
+            case "SNACK":
+              timeStr = "15:00";
+              break;
           }
         }
-        
+
         // totalCalories가 없으면 items의 calories 합계로 계산
         let totalCal = diet.totalCalories || 0;
         if (totalCal === 0 && items.length > 0) {
           totalCal = items.reduce((sum: number, item: any) => {
             const itemCal = item?.calories || 0;
-            return sum + (typeof itemCal === 'number' ? itemCal : 0);
+            return sum + (typeof itemCal === "number" ? itemCal : 0);
           }, 0);
         }
 
         // 영양소 정보 추출 및 총합 계산
         const mappedItems = items.map((item: any) => {
           // name 필드가 없을 수 있으므로 여러 가능성 확인
-          const itemName = item?.name || item?.foodName || item?.food?.name || '';
-          console.log(`🔍 [Dashboard] item 매핑:`, { 
-            item, 
-            name: itemName, 
-            itemKeys: Object.keys(item || {}) 
+          const itemName = item?.name || item?.foodName || item?.food?.name || "";
+          console.log(`🔍 [Dashboard] item 매핑:`, {
+            item,
+            name: itemName,
+            itemKeys: Object.keys(item || {}),
           });
           return {
             name: itemName,
@@ -299,16 +317,22 @@ const fetchTodayDiets = async () => {
         };
       })
     );
-    console.log('✅ [Dashboard] displayedDiets 설정 완료:', displayedDiets.value);
-    console.log('✅ [Dashboard] displayedDiets 개수:', displayedDiets.value.length);
+    console.log("✅ [Dashboard] displayedDiets 설정 완료:", displayedDiets.value);
+    console.log("✅ [Dashboard] displayedDiets 개수:", displayedDiets.value.length);
 
     // Group by TimeSlot (각 식단은 하나의 타임라인 아이템으로 표시)
     // displayedDiets에서 이미 items를 가져왔으므로 그것을 사용
     const dietTimelineItems: UnifiedTimelineItem[] = displayedDiets.value.map((diet) => {
-      const desc = diet.items.map((item) => item.name).filter(Boolean).join(", ") || "음식 정보 없음";
+      const desc =
+        diet.items
+          .map((item) => item.name)
+          .filter(Boolean)
+          .join(", ") || "음식 정보 없음";
 
       // 영양소 정보 포맷팅
-      const nutritionInfo = `탄수화물 ${Math.round(diet.totalCarbs || 0)}g · 단백질 ${Math.round(diet.totalProtein || 0)}g · 지방 ${Math.round(diet.totalFat || 0)}g`;
+      const nutritionInfo = `탄수화물 ${Math.round(diet.totalCarbs || 0)}g · 단백질 ${Math.round(
+        diet.totalProtein || 0
+      )}g · 지방 ${Math.round(diet.totalFat || 0)}g`;
       const subDesc = `${diet.totalCalories || 0} kcal · ${nutritionInfo}`;
 
       return {
@@ -332,7 +356,7 @@ const fetchTodayDiets = async () => {
     // Update stats (displayedDiets의 totalCalories 사용)
     const totalCalories = displayedDiets.value.reduce((sum, d) => sum + (d.totalCalories || 0), 0);
     dailyStats.intakeCalories = Math.round(totalCalories);
-    console.log('✅ [Dashboard] 총 칼로리 업데이트:', dailyStats.intakeCalories);
+    console.log("✅ [Dashboard] 총 칼로리 업데이트:", dailyStats.intakeCalories);
   } catch (e) {
     console.error("❌ [Dashboard] Failed to fetch diet records", e);
     console.error("❌ [Dashboard] 에러 상세:", e);
@@ -431,6 +455,10 @@ const handleDeleteDiet = async (dietId: number) => {
     await dietStore.deleteMyDiet(dietId);
     await fetchTodayDiets();
     await fetchTodayExercises(); // 통계 업데이트를 위해
+
+    // AI 주간 영양 평가 생성 트리거 (비동기)
+    localStorage.setItem("LAST_MEAL_UPDATE_TIME", new Date().toISOString());
+    statsApi.generateNutritionReview({ anchorDate: getTodayDate() }).catch((e) => console.warn(e));
   } catch (e) {
     console.error("Failed to delete diet", e);
     alert(dietStore.errorMessage || "식단 삭제에 실패했습니다.");

--- a/src/views/MealRegisterView.vue
+++ b/src/views/MealRegisterView.vue
@@ -10,8 +10,8 @@ import ToggleGroup from "@/components/ui/ToggleGroup.vue";
 import ImageWithFallback from "@/components/common/ImageWithFallback.vue";
 import { useFoodsStore } from "@/stores/foods";
 import { useDietStore } from "@/stores/diet";
-import Textarea from "@/components/ui/Textarea.vue";
 import { type UpdateMyDietItemRequest, type DietTimeSlot } from "@/api/diet";
+import statsApi from "@/api/stats";
 
 const router = useRouter();
 const dateInputRef = ref<HTMLInputElement | null>(null);
@@ -118,43 +118,28 @@ const totalNutrition = computed(() => {
 
 // Actions
 const fetchCatalogFoods = async () => {
-  console.log('🔍 fetchCatalogFoods 호출됨, 검색어:', catalogKeyword.value);
   try {
     const keyword = catalogKeyword.value.trim() || undefined;
-    console.log('📡 API 호출 시작, keyword:', keyword);
-    
-    // 직접 API 호출해서 응답 구조 확인
-    console.log('🔬 [직접 API 호출 테스트]');
-    const testResponse = await foodsStore.fetchFoods({ keyword });
-    console.log('🔬 [직접 API 호출 결과]', testResponse);
-    
-    console.log('✅ API 호출 완료, foodsStore.foods:', foodsStore.foods);
-    console.log('✅ foods 개수:', foodsStore.foods.length);
-    console.log('✅ filteredFoodOptions:', filteredFoodOptions.value);
-    console.log('✅ showAutocomplete:', showAutocomplete.value);
+    await foodsStore.fetchFoods({ keyword });
   } catch (error) {
-    console.error('❌ 음식 검색 실패:', error);
-    console.error('❌ 에러 상세:', error);
+    console.error("Failed to fetch foods:", error);
   }
 };
 
 // 실시간 검색 (debounce)
+// 실시간 검색 (debounce)
 watch(catalogKeyword, (newValue) => {
-  console.log('⌨️ 검색어 변경됨:', newValue);
   if (searchTimeout.value) {
     clearTimeout(searchTimeout.value);
   }
-  
+
   if (newValue.trim().length > 0) {
     // 검색어가 있으면 드롭다운 표시 (검색어 입력 시에는 사라지지 않음)
-    console.log('📝 검색어 있음, 드롭다운 표시');
     showAutocomplete.value = true;
     searchTimeout.value = window.setTimeout(() => {
-      console.log('⏰ Debounce 완료, API 호출 시작');
       fetchCatalogFoods();
     }, 300); // 300ms debounce
   } else {
-    console.log('📝 검색어 없음, 드롭다운 숨김');
     showAutocomplete.value = false;
   }
 });
@@ -165,18 +150,11 @@ const filteredFoodOptions = computed(() => {
     return [];
   }
   // API에서 이미 검색어로 필터링된 결과를 반환하므로, 추가 필터링 없이 그대로 사용
-  const options = foodsStore.foods.map((f) => ({
+  return foodsStore.foods.map((f) => ({
     label: `${f.name} · ${f.calories}kcal`,
     value: String(f.id),
     food: f,
   }));
-  console.log('📋 filteredFoodOptions computed 실행:', {
-    keyword: catalogKeyword.value,
-    foodsCount: foodsStore.foods.length,
-    optionsCount: options.length,
-    showAutocomplete: showAutocomplete.value
-  });
-  return options;
 });
 
 // Input 포커스/입력 핸들러
@@ -202,17 +180,17 @@ const handleSelectFood = async (foodId: string) => {
 // 외부 클릭 시 자동완성 닫기
 const handleClickOutside = (event: MouseEvent) => {
   const target = event.target as HTMLElement;
-  
+
   // Input이나 드롭다운 내부 클릭은 무시 (검색어 입력 중에는 드롭다운 유지)
   if (autocompleteContainerRef.value && autocompleteContainerRef.value.contains(target)) {
     return;
   }
-  
+
   // Input에 포커스가 있고 검색어가 있으면 드롭다운 유지
   if (inputRef.value && document.activeElement === inputRef.value && catalogKeyword.value.trim().length > 0) {
     return;
   }
-  
+
   // 실제 외부 클릭 시에만 닫기
   showAutocomplete.value = false;
 };
@@ -278,7 +256,7 @@ const loadDietForEdit = async () => {
           let baseCarbs = 0;
           let baseProtein = 0;
           let baseFat = 0;
-          
+
           // foodId가 있으면 상세 정보 조회하여 기본값 설정
           if (item.foodId) {
             try {
@@ -301,20 +279,20 @@ const loadDietForEdit = async () => {
             baseProtein = 0;
             baseFat = 0;
           }
-          
+
           // amount에 비례하여 계산
           const calculatedCalories = calculateNutrition(baseCalories, amount);
           const calculatedCarbs = calculateNutrition(baseCarbs, amount);
           const calculatedProtein = calculateNutrition(baseProtein, amount);
           const calculatedFat = calculateNutrition(baseFat, amount);
-          
+
           return {
             id: `edit-${item.dietItemId || idx}`,
             foodId: item.foodId || null,
-            name: item.name || '',
+            name: item.name || "",
             checked: true,
             amount: amount,
-            unit: 'g' as const,
+            unit: "g" as const,
             calories: calculatedCalories,
             carbs: calculatedCarbs,
             protein: calculatedProtein,
@@ -346,12 +324,12 @@ onMounted(async () => {
   }
 
   // 외부 클릭 감지 (bubble phase 사용)
-  document.addEventListener('click', handleClickOutside);
+  document.addEventListener("click", handleClickOutside);
 });
 
 onUnmounted(() => {
   // 이벤트 리스너 정리
-  document.removeEventListener('click', handleClickOutside);
+  document.removeEventListener("click", handleClickOutside);
   if (searchTimeout.value) {
     clearTimeout(searchTimeout.value);
   }
@@ -360,7 +338,7 @@ onUnmounted(() => {
 const handlePhotoUpload = () => {
   hasPhoto.value = true;
   uploadedPhotoUrl.value = "https://images.unsplash.com/photo-1546069901-ba9599a7e63c";
-  
+
   // 100g 기준 기본 영양 정보를 저장하고, amount에 비례하여 계산
   foods.value = [
     {
@@ -426,7 +404,7 @@ const handlePhotoDelete = () => {
 // 영양 정보 계산 함수 (100g 기준값을 amount에 비례하여 계산)
 const calculateNutrition = (baseValue: number, amount: number): number => {
   // baseValue는 100g 기준, amount는 실제 그램 수
-  return Math.round((baseValue * amount) / 100 * 10) / 10; // 소수점 첫째자리까지
+  return Math.round(((baseValue * amount) / 100) * 10) / 10; // 소수점 첫째자리까지
 };
 
 // amount 변경 시 영양 정보 자동 계산
@@ -454,7 +432,6 @@ const handleToggleManualInput = (id: string) => {
   if (food) food.manualInput = !food.manualInput;
 };
 
-
 const handleAddCatalogFood = async () => {
   if (!selectedCatalogFoodId.value) return;
   const foodId = Number(selectedCatalogFoodId.value);
@@ -468,10 +445,10 @@ const handleAddCatalogFood = async () => {
   const baseCarbs = selected.carbohydrate;
   const baseProtein = selected.protein;
   const baseFat = selected.fat;
-  
+
   // 초기값은 100g(1인분) 기준
   const initialAmount = 100;
-  
+
   foods.value.push({
     id: `catalog-${selected.id}-${Date.now()}`,
     foodId: selected.id,
@@ -541,8 +518,7 @@ const handleSave = async () => {
   // foodId가 없는 항목이 있으면 저장 불가
   const missingFoodId = selectedItems.filter((f) => f.foodId == null);
   if (missingFoodId.length > 0) {
-    saveErrorMessage.value =
-      "음식 DB에 등록된 음식만 저장할 수 있어요. 음식 검색에서 선택한 음식만 추가해주세요.";
+    saveErrorMessage.value = "음식 DB에 등록된 음식만 저장할 수 있어요. 음식 검색에서 선택한 음식만 추가해주세요.";
     return;
   }
 
@@ -550,67 +526,43 @@ const handleSave = async () => {
     if (isEditMode.value && editDietId.value) {
       // 수정 모드
       const updatePayload: UpdateMyDietItemRequest[] = selectedItems.map((f, index) => ({
-        foodId: f.foodId || null,
-        foodName: f.name,
-        serveCount: f.amount, // 그램 단위를 그대로 전송 (백엔드에서 인분으로 처리할 수도 있음)
-        calories: f.calories || 0,
-        carbs: f.carbs || 0,
-        protein: f.protein || 0,
-        fat: f.fat || 0,
-        orderIndex: index + 1, // 1부터 시작
+        foodId: f.foodId!,
+        serveCount: f.amount,
+        orderIndex: index + 1,
       }));
 
       // date와 selectedTime을 합쳐서 ISO datetime 형식으로 생성 (Spring Boot LocalDateTime 기본 형식)
       const dateWithTime = `${selectedDate.value}T${selectedTime.value}:00`;
-      
+
       const updatePayloadData = {
-        date: dateWithTime, // ISO datetime 형식 (e.g. "2025-12-05T08:30:00")
-        timeSlot: toTimeSlot(selectedMealType.value) as DietTimeSlot,
+        recordedAt: dateWithTime,
+        mealType: toTimeSlot(selectedMealType.value) as DietTimeSlot,
         items: updatePayload,
-        memo: memo.value.trim() ? memo.value.trim() : undefined,
       };
-      
-      // 디버깅: 실제로 보내는 데이터 확인
-      console.log('📤 [MealRegister] updateMyDiet 요청 데이터:', JSON.stringify(updatePayloadData, null, 2));
-      
+
       await dietStore.updateMyDiet(editDietId.value, updatePayloadData);
     } else {
       // 생성 모드 - API 명세에 맞춘 형식
       // date와 selectedTime을 합쳐서 ISO datetime 형식으로 생성 (Spring Boot LocalDateTime 기본 형식)
       const dateWithTime = `${selectedDate.value}T${selectedTime.value}:00`;
-      
+
       const payload = {
-        date: dateWithTime, // ISO datetime 형식 (e.g. "2025-12-05T08:30:00")
-        timeSlot: toTimeSlot(selectedMealType.value) as DietTimeSlot, // "BREAKFAST" | "LUNCH" | "DINNER" | "SNACK"
+        recordedAt: dateWithTime, // ISO datetime 형식 (e.g. "2025-12-05T08:30:00")
+        mealType: toTimeSlot(selectedMealType.value) as DietTimeSlot, // "BREAKFAST" | "LUNCH" | "DINNER" | "SNACK"
         items: selectedItems.map((f, index) => ({
-          foodId: f.foodId || null,
-          foodName: f.name,
-          serveCount: f.amount, // 그램 단위를 그대로 전송 (백엔드에서 인분으로 처리할 수도 있음)
-          calories: f.calories || 0,
-          carbs: f.carbs || 0,
-          protein: f.protein || 0,
-          fat: f.fat || 0,
-          orderIndex: index + 1, // 1부터 시작
+          foodId: f.foodId!, // 위에서 validation 했으므로 단언 가능
+          serveCount: f.amount,
+          orderIndex: index + 1,
         })),
-        memo: memo.value.trim() ? memo.value.trim() : undefined,
       };
-      
-      // 디버깅: 실제로 보내는 데이터 확인
-      console.log('📤 [MealRegister] createMyDiet 요청 데이터:', JSON.stringify(payload, null, 2));
-      console.log('📤 [MealRegister] items 개수:', payload.items.length);
-      console.log('📤 [MealRegister] 각 item:', payload.items.map(item => ({
-        foodId: item.foodId,
-        foodName: item.foodName,
-        serveCount: item.serveCount,
-        orderIndex: item.orderIndex,
-        calories: item.calories,
-        carbs: item.carbs,
-        protein: item.protein,
-        fat: item.fat,
-      })));
-      
+
       await dietStore.createMyDiet(payload);
     }
+
+    // AI 주간 영양 평가 생성 트리거 (비동기, 결과 기다리지 않음)
+    localStorage.setItem("LAST_MEAL_UPDATE_TIME", new Date().toISOString());
+    statsApi.generateNutritionReview({ anchorDate: selectedDate.value }).catch((e) => console.warn(e));
+
     router.push("/dashboard");
   } catch (e: any) {
     saveErrorMessage.value = e?.message || dietStore.errorMessage || "식단 저장 중 오류가 발생했습니다.";
@@ -726,7 +678,7 @@ const handleSave = async () => {
                 @input="handleInputChange"
                 @click.stop
               />
-              
+
               <!-- 자동완성 드롭다운 -->
               <div
                 v-if="showAutocomplete && catalogKeyword.trim().length > 0 && filteredFoodOptions.length > 0"
@@ -741,14 +693,20 @@ const handleSave = async () => {
                 >
                   <div class="text-white text-sm font-medium">{{ option.food.name }}</div>
                   <div class="text-zinc-400 text-xs mt-1">
-                    {{ option.food.calories }}kcal · 탄 {{ option.food.carbohydrate }}g · 단백질 {{ option.food.protein }}g · 지방 {{ option.food.fat }}g
+                    {{ option.food.calories }}kcal · 탄 {{ option.food.carbohydrate }}g · 단백질
+                    {{ option.food.protein }}g · 지방 {{ option.food.fat }}g
                   </div>
                 </div>
               </div>
-              
+
               <!-- 검색 결과 없음 -->
               <div
-                v-if="showAutocomplete && catalogKeyword.trim().length > 0 && !foodsStore.isLoading && filteredFoodOptions.length === 0"
+                v-if="
+                  showAutocomplete &&
+                  catalogKeyword.trim().length > 0 &&
+                  !foodsStore.isLoading &&
+                  filteredFoodOptions.length === 0
+                "
                 class="absolute z-50 w-full mt-1 bg-zinc-900 border border-zinc-800 rounded-lg shadow-lg p-4"
                 @click.stop
               >
@@ -803,10 +761,12 @@ const handleSave = async () => {
                   <!-- 수량 드롭다운 -->
                   <Select
                     :model-value="food.amount.toString()"
-                    @update:model-value="(val) => {
-                      food.amount = Number(val);
-                      updateFoodNutrition(food);
-                    }"
+                    @update:model-value="
+                      (val) => {
+                        food.amount = Number(val);
+                        updateFoodNutrition(food);
+                      }
+                    "
                     :options="servingOptions"
                     class="w-[100px] h-9 text-xs bg-zinc-900 border-zinc-700 text-white"
                   />
@@ -865,7 +825,6 @@ const handleSave = async () => {
               </div>
             </div>
           </div>
-
         </div>
       </div>
     </div>

--- a/src/views/StatsAnalysisView.vue
+++ b/src/views/StatsAnalysisView.vue
@@ -169,12 +169,57 @@ const fetchStats = async () => {
     }
 
     // Handle Nutrition Review
-    if (reviewRes.status === "fulfilled") {
-      nutritionReview.value = reviewRes.value.data;
-    } else {
-      console.error("Failed to fetch nutrition review:", reviewRes.reason);
-      nutritionReview.value = null;
-    }
+    const handleNutritionReviewFetch = async () => {
+      // Polling Logic
+      let attempts = 0;
+      const maxAttempts = 10;
+      const pollInterval = 2000;
+
+      const isNutritionReviewValid = (review: any) => {
+        if (!review || !review.evaluated) return false;
+
+        const lastUpdateTimeStr = localStorage.getItem("LAST_MEAL_UPDATE_TIME");
+        if (!lastUpdateTimeStr) return true;
+
+        const lastUpdateTime = new Date(lastUpdateTimeStr).getTime();
+        const generatedTime = new Date(review.generatedAt).getTime();
+
+        // If generatedAt is OLDER than last update, it's stale.
+        return generatedTime >= lastUpdateTime;
+      };
+
+      const poll = async () => {
+        try {
+          const res = await statsApi.getNutritionReview(selectedWeek.value);
+          if (isNutritionReviewValid(res.data)) {
+            nutritionReview.value = res.data;
+            return true;
+          }
+        } catch (e) {
+          console.warn("Polling nutrition review failed:", e);
+        }
+        return false;
+      };
+
+      // Initial Check
+      if (reviewRes.status === "fulfilled" && isNutritionReviewValid(reviewRes.value.data)) {
+        nutritionReview.value = reviewRes.value.data;
+      } else {
+        nutritionReview.value = null; // Show loading state
+
+        console.log("Starting polling for fresh nutrition review...");
+        const interval = setInterval(async () => {
+          attempts++;
+          const success = await poll();
+          if (success || attempts >= maxAttempts) {
+            clearInterval(interval);
+            if (success) {
+              console.log("Fresh nutrition review fetched via polling!");
+            } else console.log("Nutrition Polling timed out.");
+          }
+        }, pollInterval);
+      }
+    };
 
     // Handle Exercise Review
     const handleExerciseReviewFetch = async () => {
@@ -194,7 +239,6 @@ const fetchStats = async () => {
         const generatedTime = new Date(review.generatedAt).getTime();
 
         // If generatedAt is OLDER than last update, it's stale.
-        // Give a small buffer (e.g., 1 sec) just in case of clock skew, though strict comparison is usually fine.
         return generatedTime >= lastUpdateTime;
       };
 
@@ -227,15 +271,13 @@ const fetchStats = async () => {
             clearInterval(interval);
             if (success) {
               console.log("Fresh exercise review fetched via polling!");
-              // Optional: Clear timestamp after success?
-              // No, better keep it to compare against future changes unless we want to clear it.
-              // But keeping it is fine as future generations will be even newer.
             } else console.log("Polling timed out.");
           }
         }, pollInterval);
       }
     };
 
+    handleNutritionReviewFetch();
     handleExerciseReviewFetch();
   } catch (error) {
     console.error("Unexpected error:", error);
@@ -353,37 +395,51 @@ const exerciseChartData = computed<ChartData<"bar" | "line">>(() => {
       <!-- AI 분석 카드 그리드 (영양 + 운동) -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <!-- 0. 주간 영양 AI 분석 -->
-        <div v-if="nutritionReview" class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 space-y-4 h-full">
+        <div class="bg-zinc-900 border border-zinc-800 rounded-xl p-6 space-y-4 h-full flex flex-col">
           <div class="flex items-center justify-between">
             <h3 class="text-xl text-white flex items-center gap-2">✨ 영양 분석</h3>
-            <span class="text-xs text-zinc-500" v-if="nutritionReview.generatedAt">
+            <span class="text-xs text-zinc-500" v-if="nutritionReview && nutritionReview.generatedAt">
               {{ new Date(nutritionReview.generatedAt).toLocaleDateString() }}
             </span>
           </div>
 
-          <!-- 상태 뱃지 그리드 -->
-          <div class="grid grid-cols-2 gap-2">
-            <div
-              v-for="key in ['calorieStatus', 'carbohydrateStatus', 'proteinStatus', 'fatStatus']"
-              :key="key"
-              class="bg-zinc-950 rounded-lg p-2 md:p-3 border border-zinc-800 flex items-center justify-between"
-            >
-              <span class="text-zinc-400 text-xs md:text-sm">{{ getStatusLabel(key) }}</span>
-              <span
-                class="text-xs px-2 py-1 rounded border font-medium"
-                :class="getStatusBadge(nutritionReview[key]).class"
+          <!-- Case 1: Data Available -->
+          <template v-if="nutritionReview">
+            <!-- 상태 뱃지 그리드 -->
+            <div class="grid grid-cols-2 gap-2">
+              <div
+                v-for="key in ['calorieStatus', 'carbohydrateStatus', 'proteinStatus', 'fatStatus']"
+                :key="key"
+                class="bg-zinc-950 rounded-lg p-2 md:p-3 border border-zinc-800 flex items-center justify-between"
               >
-                {{ getStatusBadge(nutritionReview[key]).text }}
-              </span>
+                <span class="text-zinc-400 text-xs md:text-sm">{{ getStatusLabel(key) }}</span>
+                <span
+                  class="text-xs px-2 py-1 rounded border font-medium"
+                  :class="getStatusBadge(nutritionReview[key]).class"
+                >
+                  {{ getStatusBadge(nutritionReview[key]).text }}
+                </span>
+              </div>
             </div>
-          </div>
 
-          <!-- 요약 텍스트 -->
-          <div class="bg-zinc-950/50 rounded-lg p-4 border border-zinc-800/50">
-            <p class="text-zinc-300 leading-relaxed whitespace-pre-line text-sm">
-              {{ nutritionReview.summaryText }}
-            </p>
-          </div>
+            <!-- 요약 텍스트 -->
+            <div class="bg-zinc-950/50 rounded-lg p-4 border border-zinc-800/50 flex-1">
+              <p class="text-zinc-300 leading-relaxed whitespace-pre-line text-sm">
+                {{ nutritionReview.summaryText }}
+              </p>
+            </div>
+          </template>
+
+          <!-- Case 2: Loading / Analyzing -->
+          <template v-else>
+            <div class="flex-1 flex flex-col items-center justify-center space-y-4 py-8">
+              <Loader2 class="w-8 h-8 text-emerald-500 animate-spin" />
+              <div class="text-center space-y-1">
+                <p class="text-zinc-300 font-medium">AI가 영양 섭취를 분석하고 있어요</p>
+                <p class="text-zinc-500 text-sm">잠시만 기다려주세요...</p>
+              </div>
+            </div>
+          </template>
         </div>
 
         <!-- 0.5 주간 운동 AI 분석 (New) -->


### PR DESCRIPTION
## 🔗 관련 이슈

> closes #19

## ✨ 작업 내용

* **AI 식단 평가(Diet Review) 연동**

  * StatsAnalysisView에서 주간 식단 평가 조회 후 카드 UI로 표시
  * 평가 미생성/분석 중에는 카드 숨김 대신 **‘AI 분석 중’ 로딩 상태(Spinner)** 표시

* **비동기 생성 트리거 + 데이터 동기화(Polling)**

  * 운동 기록 저장/수정(MealRegisterView), 삭제(DashboardView) 시 **대기 없이 화면 전환** + 백그라운드로 평가 생성 트리거
  * 로컬스토리지에 `LAST_MEAL_UPDATE_TIME` 저장
  * 통계 진입 시 `generatedAt < LAST_MEAL_UPDATE_TIME` 이면 **2초 간격 Polling**으로 최신 평가 자동 갱신

* **식단 API 명세 불일치 관련 프론트 측 필드명 수정 (recordDate → recordedAt로 통일)**

## 📌 참고 사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

